### PR TITLE
Implement orderedmap packing, fix minor bugs, use go 1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Fetch new (`diff-only`) assets for version `1.600.0` into `./dump` directory and
 wfax fetch --diff-only --version 1.600.0 ./dump && wfax extract --indent 2 ./dump ./output
 ```
 
-Fetch character comics (`--comics 1`) with `10` maximum concurrent requests into `./comics` directory.
+Fetch character comics (`--comics 1`) with `10` maximum concurrent requests into `./comics` directory:
 ```sh
 wfax fetch --comics 1 --concurrency 10 ./comics
 ```
@@ -40,6 +40,11 @@ wfax extract --eliyabot --no-default-paths ./dump ./output
 Extract equipment image assets for eliyabot:
 ```sh
 wfax sprite --eliyabot ./dump ./output
+```
+
+Pack extracted files in `./output` back into assets in `./dump`:
+```sh
+wfax pack ./output ./dump
 ```
 
 For more detailed information, use `wfax help`.

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -8,31 +8,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var packPathList string
 var packConcurrency int
 
 var packCmd = &cobra.Command{
 	Use:   "pack [src] [dest]",
-	Short: "Pack files from src into game format at dest",
+	Short: "Pack files from src into game assets at dest (currently only supports default directory structure)",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		config := wf.ExtractorConfig{
-			SrcPath:        filepath.Clean(args[1]),
-			DestPath:       filepath.Clean(args[0]),
-			PathList:       filepath.Clean(packPathList),
-			NoDefaultPaths: false,
-			Concurrency:    packConcurrency,
-			Indent:         0,
-			FlattenCSV:     false,
-			Eliyabot:       false,
+		config := wf.PackerConfig{
+			SrcPath:     filepath.Clean(args[0]),
+			DestPath:    filepath.Clean(args[1]),
+			Concurrency: packConcurrency,
 		}
 
-		extractor, err := wf.NewExtractor(&config)
+		packer, err := wf.NewPacker(&config)
 		if err != nil {
 			log.Fatalln(err)
 		}
 
-		err = extractor.PackAssets()
+		err = packer.PackAssets()
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -41,6 +35,5 @@ var packCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(packCmd)
-	packCmd.Flags().StringVarP(&packPathList, "path-list", "p", "", "Path to newline delimited file containing possible asset paths (default \"[dest]/.pathlist\")")
 	packCmd.Flags().IntVarP(&packConcurrency, "concurrency", "c", 5, "Maximum number of concurrent file extractions")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,14 @@
 module github.com/blead/wfax
 
-go 1.20
+go 1.22
 
 require (
-	github.com/Jeffail/gabs/v2 v2.6.1
+	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/disintegration/imaging v1.6.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/logutils v1.0.0
-	github.com/iancoleman/orderedmap v0.2.0
+	github.com/iancoleman/orderedmap v0.3.0
 	github.com/remyoudompheng/goamf v0.0.0-20171008193039-e340f13844ae
 	github.com/spf13/cobra v1.6.1
 	github.com/tinylib/msgp v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Jeffail/gabs/v2 v2.6.1 h1:wwbE6nTQTwIMsMxzi6XFQQYRZ6wDc1mSdxoAN+9U4Gk=
 github.com/Jeffail/gabs/v2 v2.6.1/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
+github.com/Jeffail/gabs/v2 v2.7.0 h1:Y2edYaTcE8ZpRsR2AtmPu5xQdFDIthFG0jYhu5PY8kg=
+github.com/Jeffail/gabs/v2 v2.7.0/go.mod h1:dp5ocw1FvBBQYssgHsG7I1WYsiLRtkUaB1FEtSwvNUw=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
@@ -18,6 +20,8 @@ github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/iancoleman/orderedmap v0.2.0 h1:sq1N/TFpYH++aViPcaKjys3bDClUEU7s5B+z6jq8pNA=
 github.com/iancoleman/orderedmap v0.2.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
+github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
+github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJDkXXS7VoV7XGE=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jcoene/gologger v0.0.0-20150511233422-6bdddb86fa18 h1:JD65kBPjb6bWQSBtxhDUXqit/d4AUxyGm0QSPj0BdWM=

--- a/pkg/concurrency/dispatcher.go
+++ b/pkg/concurrency/dispatcher.go
@@ -34,6 +34,7 @@ func Dispatcher[D any, O any](dispatch func(*Item[D, O]) ([]*Item[D, O], error),
 		}
 		pending += len(out)
 		for _, o := range out {
+			items = append(items, o)
 			dch <- o
 		}
 	}

--- a/pkg/encoding/json.go
+++ b/pkg/encoding/json.go
@@ -3,6 +3,9 @@ package encoding
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+
+	omap "github.com/iancoleman/orderedmap"
 )
 
 func jsonMarshalNoEscape(v any) ([]byte, error) {
@@ -11,4 +14,50 @@ func jsonMarshalNoEscape(v any) ([]byte, error) {
 	encoder.SetEscapeHTML(false)
 	err := encoder.Encode(v)
 	return output.Bytes(), err
+}
+
+func shallowUnmarshalJSONObject(b []byte) (*omap.OrderedMap, error) {
+	dec := json.NewDecoder(bytes.NewReader(b))
+
+	// read '{'
+	t, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	delim, ok := t.(json.Delim)
+	if !ok || delim != '{' {
+		return nil, fmt.Errorf("shallowUnmarshalJSONObject: unexpected token, expected='{', found='%s', obj=%s", delim.String(), string(b))
+	}
+
+	o := omap.New()
+
+	for dec.More() {
+		// read key
+		t, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key := t.(string)
+
+		// read value
+		var value json.RawMessage
+		err = dec.Decode(&value)
+		if err != nil {
+			return nil, err
+		}
+
+		o.Set(key, value)
+	}
+
+	// read '}'
+	t, err = dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	delim, ok = t.(json.Delim)
+	if !ok || delim != '}' {
+		return nil, fmt.Errorf("shallowUnmarshalJSONObject: unexpected token, expected='}', found='%s', obj=%s", delim.String(), string(b))
+	}
+
+	return o, nil
 }

--- a/pkg/encoding/zlib.go
+++ b/pkg/encoding/zlib.go
@@ -15,3 +15,18 @@ func readZlib(compressed []byte) ([]byte, error) {
 
 	return io.ReadAll(r)
 }
+
+func writeZlib(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	w := zlib.NewWriter(&buf)
+	_, err := w.Write(data)
+	if err != nil {
+		return nil, err
+	}
+	err = w.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/pkg/wf/extractor.go
+++ b/pkg/wf/extractor.go
@@ -308,47 +308,6 @@ func extractFile(path string, p parser, config *ExtractorConfig) ([][]byte, erro
 	return p.output(data, config)
 }
 
-func packFile(path string, p parser, config *ExtractorConfig) error {
-	src, err := p.getDest(path, config)
-	if err != nil {
-		return err
-	}
-	dest, err := p.getSrc(path, config)
-	if err != nil {
-		return err
-	}
-
-	srcFile, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("packFile: src open error, src=%s, dest=%s, %w", src, dest, err)
-	}
-	defer srcFile.Close()
-
-	data, err := io.ReadAll(srcFile)
-	if err != nil {
-		return fmt.Errorf("packFile: src read error, src=%s, dest=%s, %w", src, dest, err)
-	}
-
-	data, err = p.unparse(data, config)
-	if err != nil {
-		return fmt.Errorf("packFile: src unparse error, src=%s, dest=%s, %w", src, dest, err)
-	}
-
-	os.MkdirAll(filepath.Dir(dest), 0777)
-	destFile, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
-	if err != nil {
-		return fmt.Errorf("packFile: dest open error, src=%s, dest=%s, %w", src, dest, err)
-	}
-	defer destFile.Close()
-
-	_, err = io.Copy(destFile, bytes.NewReader(data))
-	if err != nil {
-		return fmt.Errorf("packFile: dest write error, src=%s, dest=%s, %w", src, dest, err)
-	}
-
-	return nil
-}
-
 type extractParams struct {
 	path    string
 	parsers []parser
@@ -366,17 +325,6 @@ func extractPath(i *concurrency.Item[*extractParams, [][]byte]) ([][]byte, error
 		// o = nil if file does not exist with format p
 		if o != nil {
 			output = append(output, o)
-		}
-	}
-	return encoding.Flatten(output), nil
-}
-
-func packPath(i *concurrency.Item[*extractParams, [][]byte]) ([][]byte, error) {
-	var output [][][]byte
-	for _, p := range i.Data.parsers {
-		err := packFile(i.Data.path, p, i.Data.config)
-		if err != nil {
-			return nil, err
 		}
 	}
 	return encoding.Flatten(output), nil
@@ -433,64 +381,8 @@ func (extractor *Extractor) extract() error {
 	return extractor.writePathList(pathList)
 }
 
-func (extractor *Extractor) pack() error {
-	err := os.MkdirAll(extractor.config.DestPath, 0777)
-	if err != nil {
-		return err
-	}
-
-	paths, err := extractor.getInitialPaths()
-	if err != nil {
-		return err
-	}
-	items := []*concurrency.Item[*extractParams, [][]byte]{{Output: paths}}
-	seenPaths := map[string]bool{}
-
-	err = concurrency.Dispatcher(
-		func(i *concurrency.Item[*extractParams, [][]byte]) ([]*concurrency.Item[*extractParams, [][]byte], error) {
-			var output []*concurrency.Item[*extractParams, [][]byte]
-			if i.Output != nil {
-				for _, p := range i.Output {
-					if !seenPaths[string(p)] {
-						seenPaths[string(p)] = true
-						output = append(output, &concurrency.Item[*extractParams, [][]byte]{
-							Data: &extractParams{
-								path:    string(p),
-								parsers: extractor.parsers,
-								config:  extractor.config,
-							},
-							Output: nil,
-							Err:    nil,
-						})
-					}
-				}
-			}
-			return output, nil
-		},
-		packPath,
-		items,
-		extractor.config.Concurrency,
-	)
-	if err != nil {
-		return err
-	}
-
-	var pathList []string
-	for p := range seenPaths {
-		if len(p) > 0 {
-			pathList = append(pathList, p)
-		}
-	}
-	return extractor.writePathList(pathList)
-}
-
 // ExtractAssets extracts assets from downloaded files.
 func (extractor *Extractor) ExtractAssets() error {
 	log.Println("[INFO] Extracting assets")
 	return extractor.extract()
-}
-
-func (packer *Extractor) PackAssets() error {
-	log.Println("[INFO] Packing assets")
-	return packer.pack()
 }

--- a/pkg/wf/hasher.go
+++ b/pkg/wf/hasher.go
@@ -1,10 +1,12 @@
 package wf
 
+import "path/filepath"
+
 // Hasher hashes
 type Hasher struct {
 }
 
 // HashAssetPath returns hashed asset path.
 func (*Hasher) HashAssetPath(path string) (string, error) {
-	return sha1Digest(path, digestSalt)
+	return sha1Digest(filepath.ToSlash(path), digestSalt)
 }

--- a/pkg/wf/packer.go
+++ b/pkg/wf/packer.go
@@ -1,0 +1,219 @@
+package wf
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/blead/wfax/pkg/concurrency"
+)
+
+// PackerConfig is the configuration for the packer.
+type PackerConfig struct {
+	SrcPath     string
+	DestPath    string
+	Concurrency int
+}
+
+// DefaultPackerConfig generates a default configuration.
+func DefaultPackerConfig() *PackerConfig {
+	return &PackerConfig{
+		SrcPath:     "",
+		DestPath:    "",
+		Concurrency: 5,
+	}
+}
+
+// Packer unparses and packs WF assets.
+type Packer struct {
+	config  *PackerConfig
+	parsers []parser
+}
+
+// NewPacker creates a new packer with the supplied configuration.
+// If the configuration is nil, use DefaultPackerConfig.
+func NewPacker(config *PackerConfig) (*Packer, error) {
+	def := DefaultPackerConfig()
+	if def == nil {
+		return nil, fmt.Errorf("NewPacker: default configuration is nil")
+	}
+
+	if config == nil {
+		config = def
+	}
+
+	if config.SrcPath == "" || config.SrcPath == "." {
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		config.SrcPath = wd
+	}
+	config.SrcPath = filepath.Clean(config.SrcPath)
+
+	if config.DestPath == "" || config.DestPath == "." {
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		config.DestPath = wd
+	}
+	config.DestPath = filepath.Clean(config.DestPath)
+
+	if config.Concurrency == 0 {
+		config.Concurrency = 5
+	}
+
+	parsers := []parser{
+		// &amf3Parser{ext: ".action.dsl"},
+		// &esdlParser{&amf3Parser{ext: ".esdl"}},
+		&orderedmapParser{}, // needs to be last because of ambiguous file extension
+	}
+
+	return &Packer{config: config, parsers: parsers}, nil
+}
+
+func packFile(src string, p parser, config *PackerConfig) (bool, error) {
+	path, found := p.matchDest(src, config)
+	if !found {
+		return false, nil
+	}
+
+	dest, err := p.getSrc(path, &ExtractorConfig{SrcPath: config.DestPath})
+	if err != nil {
+		return false, err
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return false, fmt.Errorf("packFile: src open error, src=%s, dest=%s, %w", src, dest, err)
+	}
+	defer srcFile.Close()
+
+	data, err := io.ReadAll(srcFile)
+	if err != nil {
+		return false, fmt.Errorf("packFile: src read error, src=%s, dest=%s, %w", src, dest, err)
+	}
+
+	data, err = p.unparse(data, config)
+	if err != nil {
+		return false, fmt.Errorf("packFile: src unparse error, src=%s, dest=%s, %w", src, dest, err)
+	}
+
+	os.MkdirAll(filepath.Dir(dest), 0777)
+	destFile, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return false, fmt.Errorf("packFile: dest open error, src=%s, dest=%s, %w", src, dest, err)
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, bytes.NewReader(data))
+	if err != nil {
+		return false, fmt.Errorf("packFile: dest write error, src=%s, dest=%s, %w", src, dest, err)
+	}
+
+	return true, nil
+}
+
+type packParams struct {
+	path    string
+	parsers []parser
+	config  *PackerConfig
+}
+
+func packPath(i *concurrency.Item[*packParams, []string]) ([]string, error) {
+	f, err := os.Open(i.Data.path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	fileInfo, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	// f is dir: return paths inside
+	if fileInfo.IsDir() {
+		dirnames, err := f.Readdirnames(0)
+		if err != nil {
+			return nil, err
+		}
+
+		var paths []string
+		for _, dn := range dirnames {
+			paths = append(paths, filepath.Join(i.Data.path, dn))
+		}
+
+		return paths, nil
+	}
+
+	// f is file: pack the file
+	for _, p := range i.Data.parsers {
+		found, err := packFile(i.Data.path, p, i.Data.config)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			break
+		}
+	}
+	return nil, nil
+}
+
+func (packer *Packer) pack() error {
+	err := os.MkdirAll(packer.config.DestPath, 0777)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(packer.config.SrcPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	dirnames, err := f.Readdirnames(0)
+	if err != nil {
+		return err
+	}
+
+	var paths []string
+	for _, dn := range dirnames {
+		paths = append(paths, filepath.Join(packer.config.SrcPath, dn))
+	}
+
+	items := []*concurrency.Item[*packParams, []string]{{Output: paths}}
+
+	return concurrency.Dispatcher(
+		func(i *concurrency.Item[*packParams, []string]) ([]*concurrency.Item[*packParams, []string], error) {
+			var output []*concurrency.Item[*packParams, []string]
+			if i.Output != nil {
+				for _, p := range i.Output {
+					output = append(output, &concurrency.Item[*packParams, []string]{
+						Data: &packParams{
+							path:    p,
+							parsers: packer.parsers,
+							config:  packer.config,
+						},
+						Output: nil,
+						Err:    nil,
+					})
+				}
+			}
+			return output, nil
+		},
+		packPath,
+		items,
+		packer.config.Concurrency,
+	)
+}
+
+// PackAssets packs extracted files back into game asset format.
+func (packer *Packer) PackAssets() error {
+	log.Println("[INFO] Packing assets")
+	return packer.pack()
+}

--- a/pkg/wf/utils.go
+++ b/pkg/wf/utils.go
@@ -28,6 +28,18 @@ func findAllPaths(b []byte) ([][]byte, error) {
 	return pattern.FindAll(b, -1), nil
 }
 
+func matchPath(fullpath string, base string, ext string) (string, bool) {
+	if strings.HasPrefix(fullpath, base) && strings.HasSuffix(fullpath, ext) {
+		path, err := filepath.Rel(base, fullpath[0:len(fullpath)-len(ext)])
+		if err != nil {
+			log.Printf("[WARN] matchPath: filepath.Rel error, err=%v\n", err)
+		} else {
+			return path, true
+		}
+	}
+	return "", false
+}
+
 func sha256Checksum(reader io.Reader) ([]byte, error) {
 	h := sha256.New()
 	_, err := io.Copy(h, reader)


### PR DESCRIPTION
A follow up to #1. Also found and fixed a few bugs along the way. 😅 

This fully implements a dedicated `Packer` used for repacking files into WF assets.

Still undecided on what a good format for specifying custom paths would be, so we will stick with the default directory structure for now. The current implementation will work out-of-the-box with any directory extracted as a result of `wfax extract`.